### PR TITLE
#3 regexp patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [action.yml](./action.yml)
 steps:
 - uses: deepakputhraya/action-pr-title@master
   with:
-    regex: '^(#\d+ )?- \w+' # Regex the title should match. By default, expects title to start with issue number, like: "#23 - title" or a dash, like: "- title"
+    regex: '^(#\d+ )?- .+' # Regex the title should match. By default, expects title to start with issue number, like: "#23 - title" or a dash, like: "- title"
     allowed_prefixes: 'feature,fix,JIRA' # title should start with the given prefix, empty by default
     disallowed_prefixes: 'feat/,hotfix' # title should not start with the given prefix, empty by default
     prefix_case_sensitive: false # title prefix are case insensitive. Default: false

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   regex:
     description: 'Regex to validate the pull request title'
     required: false
-    default: '^(#\d+ )?- \w+'
+    default: '^(#\d+ )?- .+'
   allowed_prefixes:
     description: 'Comma separated list of prefix allowed to be used in title. eg: feature,hotfix,JIRA-'
     required: false


### PR DESCRIPTION
This PR tweaks the default regexp so that titles starting with non-word characters (like parens) can pass

should close #3 